### PR TITLE
Document changes to createImageBitmap

### DIFF
--- a/files/en-us/mozilla/firefox/releases/93/index.html
+++ b/files/en-us/mozilla/firefox/releases/93/index.html
@@ -33,6 +33,10 @@ tags:
 
 <h3 id="JavaScript">JavaScript</h3>
 
+<ul>
+  <li>The properties <code>imageOrientation</code> and <code>premultiplyAlpha</code> can be passed to the method {{domxref("createImageBitmap()")}} using the <code>options</code> object ({{bug(136725 1)}}).</li>
+</ul>
+
 <h4 id="removals_js">Removals</h4>
 
 <h3 id="HTTP">HTTP</h3>


### PR DESCRIPTION
As title

<!-- Please provide the following information to help us review this PR: -->

> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

Documents options added to createImageBitmap() added in FF Bug 1367251

> What was wrong/why is this fix needed? (quick summary only)

Not already documented in FF92 'whats new'.

> Anything else that could help us review it
